### PR TITLE
fix(types): Fix provider type in constructor

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,7 +26,7 @@ declare class UssdMenu extends EventEmitter {
     constructor(opts?: UssdMenu.UssdMenuOptions);
 
     session: any;
-    provider: UssdMenu.UssdMenuOptions.provider;
+    provider: UssdMenu.UssdMenuProvider;
     args: UssdMenu.UssdGatewayArgs;
     states: Array<UssdState>;
     result: string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ussd-menu-builder",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Easily compose USSD menus using states, compatible with Africastalking API",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
My previous fix split up the Provider type, but I still needed to reference it in my interface. This is the first & only declaration file I've made, so it's still a bit of a learning process for me, but I have this one working in production now so I think it's all working.