### PR TITLE
Handle Hubtel Initiation for long-codes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -46,9 +46,12 @@ declare class UssdMenu extends EventEmitter {
 
     mapArgs(args: UssdMenu.UssdGatewayArgs | UssdMenu.HubtelArgs): UssdMenu.UssdGatewayArgs;
 
+
     onResult?(result: string | UssdMenu.HubtelResponse): void;
 
     resolveRoute(route: string, callback: Function): void;
+
+    resolve?(value: string): void;
 
     run(args: UssdMenu.UssdGatewayArgs, onResult?: Function): Promise<string>;
 

--- a/lib/ussd-menu.js
+++ b/lib/ussd-menu.js
@@ -308,10 +308,27 @@ class UssdMenu extends EventEmitter {
                 sessionId: args.SessionId,
                 phoneNumber: `+${args.Mobile}`,
                 serviceCode: args.ServiceCode,
-                text: args.Type === 'Initiation' ? '' : args.Message,
+                text: args.Type === 'Initiation' ? this.parseHubtelInitiationText(args) : args.Message,
             };
         } else {
             this.args = args;
+        }
+    }
+
+    /*
+     * If message equals shortcode, ignore.
+     * Otherwise parse message as an initial route
+     * For example, if servicecode is *714*5# and initial text is
+     * *714*5*3*100*1#, then the text/route is 3*100*1
+     */
+    parseHubtelInitiationText(hubtelArgs) {
+        const { ServiceCode: serviceCode, Message: text } = hubtelArgs;
+        if (text === `*${serviceCode}#`) {
+            return '';
+        } else {
+            // Remove service code, first asterisk and end hash, treat rest as a route
+            const routeStart = serviceCode.length + 2;
+            return text.slice(routeStart, -1);
         }
     }
 
@@ -325,14 +342,13 @@ class UssdMenu extends EventEmitter {
             if (this.session === null) {
                 return this.emit('error', new Error('Session config required for Hubtel provider'));
             } else if (args.Type === 'Initiation') {
-                // Ignore initial message
-                return this.session.set('route', '').then(() => '');
+                // Parse initial message for a route
+                const route = this.parseHubtelInitiationText(args);
+                return this.session.set('route', route).then(() => route);
             } else {
                 return this.session.get('route').then(pastRoute => {
                     const route = pastRoute ? `${pastRoute}*${this.args.text}` : this.args.text;
-                    return this.session.set('route', route).then(() => {
-                        return route;
-                    });
+                    return this.session.set('route', route).then(() => route);
                 });
             }
         } else {


### PR DESCRIPTION
Hey @habbes - been using this internally for about 6 months now but wanted to contribute it back to the library.

This allows USSD users on Hubtel to send us an initial long-code that will send them directly to a route. It's different from the AT handling because Hubtel uses "Initiation" vs "Response" states instead of sending the full route as asterisk-joined text like AT does.

Let me know any questions or comments.